### PR TITLE
feat: 즐겨찾기 API 기능 구현 (추가, 조회, 삭제)

### DIFF
--- a/src/main/java/com/example/baekseokmapbackend/config/SecurityConfig.java
+++ b/src/main/java/com/example/baekseokmapbackend/config/SecurityConfig.java
@@ -1,51 +1,52 @@
 package com.example.baekseokmapbackend.config;
 
-import com.example.baekseokmapbackend.security.JwtAuthenticationFilter; // 1. 필터 임포트
-import com.example.baekseokmapbackend.security.JwtTokenProvider; // 2. JwtTokenProvider 임포트
-import lombok.RequiredArgsConstructor; // 3. RequiredArgsConstructor 임포트
+import com.example.baekseokmapbackend.security.JwtAuthenticationFilter;
+import com.example.baekseokmapbackend.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer; // (이전 코드에서 추가된 임포트)
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder; // (이전 코드에서 빠졌던 임포트)
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter; // 4. 필터 위치 지정을 위해 임포트
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor // 5. final 필드 주입을 위해 추가
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider; // 6. JwtTokenProvider 주입
-    private final JwtAuthenticationFilter jwtAuthenticationFilter; // 7. 우리가 만든 필터 주입
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    // ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+    // (오류 수정) 이 메소드가 빠져있었습니다!
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+    // ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .httpBasic(basic -> basic.disable())
-                .formLogin(form -> form.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 (만약 dev 프로필에서 쓴다면)
-                        // (팀원이 Docker(MySQL)로 바꿨다면 이 줄은 없어도 무방합니다)
-                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .headers(headers -> headers.frameOptions(frame -> frame.disable()));
-
-        // 8. ★★★★★ 가장 중요한 부분 ★★★★★
-        // Spring Security의 기본 인증 필터(UsernamePasswordAuthenticationFilter)가 실행되기 전에,
-        // 우리가 만든 'jwtAuthenticationFilter'를 먼저 실행하도록 순서를 지정합니다.
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
-        return http.build();
+                .headers(headers ->
+                        headers.frameOptions(frame -> frame.disable()))
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
     }
 }

--- a/src/main/java/com/example/baekseokmapbackend/controller/TestController.java
+++ b/src/main/java/com/example/baekseokmapbackend/controller/TestController.java
@@ -1,0 +1,20 @@
+package com.example.baekseokmapbackend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+    /**
+     * 인증이 필요한 테스트 API (GET 요청)
+     * (GET /api/test)
+     */
+    @GetMapping("/test")
+    public ResponseEntity<String> test() {
+        return ResponseEntity.ok("GET /api/test 인증 성공!");
+    }
+}

--- a/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
@@ -1,0 +1,29 @@
+package com.example.baekseokmapbackend.favorite.controller;
+
+import com.example.baekseokmapbackend.favorite.dto.FavoriteAddRequest;
+import com.example.baekseokmapbackend.favorite.service.FavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/favorites") // /api/favorites 경로의 요청을 처리
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    /**
+     * 즐겨찾기 추가 API
+     * (POST /api/favorites)
+     */
+    @PostMapping
+    public ResponseEntity<String> addFavorite(@RequestBody FavoriteAddRequest request) {
+        favoriteService.addFavorite(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("즐겨찾기에 추가되었습니다.");
+    }
+}

--- a/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
@@ -1,18 +1,14 @@
 package com.example.baekseokmapbackend.favorite.controller;
 
 import com.example.baekseokmapbackend.favorite.dto.FavoriteAddRequest;
-import com.example.baekseokmapbackend.favorite.dto.FavoriteResponse; // 1. FavoriteResponse 임포트
+import com.example.baekseokmapbackend.favorite.dto.FavoriteResponse;
 import com.example.baekseokmapbackend.favorite.service.FavoriteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping; // 2. GetMapping 임포트
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List; // 3. List 임포트
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/favorites")
@@ -27,6 +23,7 @@ public class FavoriteController {
      */
     @PostMapping
     public ResponseEntity<String> addFavorite(@RequestBody FavoriteAddRequest request) {
+        // ... (이전과 동일) ...
         favoriteService.addFavorite(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("즐겨찾기에 추가되었습니다.");
     }
@@ -37,7 +34,18 @@ public class FavoriteController {
      */
     @GetMapping
     public ResponseEntity<List<FavoriteResponse>> getFavorites() {
+        // ... (이전과 동일) ...
         List<FavoriteResponse> favorites = favoriteService.getFavorites();
-        return ResponseEntity.ok(favorites); // 200 OK와 함께 목록 반환
+        return ResponseEntity.ok(favorites);
+    }
+
+    /**
+     * 즐겨찾기 삭제 API (Room ID 기반)
+     * (DELETE /api/favorites?roomId=1)
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> deleteFavorite(@RequestParam Integer roomId) {
+        favoriteService.deleteFavoriteByRoomId(roomId);
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/controller/FavoriteController.java
@@ -1,17 +1,21 @@
 package com.example.baekseokmapbackend.favorite.controller;
 
 import com.example.baekseokmapbackend.favorite.dto.FavoriteAddRequest;
+import com.example.baekseokmapbackend.favorite.dto.FavoriteResponse; // 1. FavoriteResponse 임포트
 import com.example.baekseokmapbackend.favorite.service.FavoriteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping; // 2. GetMapping 임포트
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List; // 3. List 임포트
+
 @RestController
-@RequestMapping("/api/favorites") // /api/favorites 경로의 요청을 처리
+@RequestMapping("/api/favorites")
 @RequiredArgsConstructor
 public class FavoriteController {
 
@@ -25,5 +29,15 @@ public class FavoriteController {
     public ResponseEntity<String> addFavorite(@RequestBody FavoriteAddRequest request) {
         favoriteService.addFavorite(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("즐겨찾기에 추가되었습니다.");
+    }
+
+    /**
+     * 즐겨찾기 목록 조회 API
+     * (GET /api/favorites)
+     */
+    @GetMapping
+    public ResponseEntity<List<FavoriteResponse>> getFavorites() {
+        List<FavoriteResponse> favorites = favoriteService.getFavorites();
+        return ResponseEntity.ok(favorites); // 200 OK와 함께 목록 반환
     }
 }

--- a/src/main/java/com/example/baekseokmapbackend/favorite/dto/FavoriteAddRequest.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/dto/FavoriteAddRequest.java
@@ -1,0 +1,8 @@
+package com.example.baekseokmapbackend.favorite.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FavoriteAddRequest {
+    private Integer roomId;
+}

--- a/src/main/java/com/example/baekseokmapbackend/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,24 @@
+package com.example.baekseokmapbackend.favorite.dto;
+
+import com.example.baekseokmapbackend.favorite.domain.Favorite;
+import com.example.baekseokmapbackend.map.domain.Room;
+import lombok.Getter;
+
+@Getter
+public class FavoriteResponse {
+
+    private Long favoriteId;
+    private Integer roomId;
+    private String roomNumber;
+    private String roomName;
+
+    // Favorite 엔티티를 FavoriteResponse DTO로 변환하는 생성자
+    public FavoriteResponse(Favorite favorite) {
+        Room room = favorite.getRoom(); // 즐겨찾기에서 Room 정보 가져오기
+
+        this.favoriteId = favorite.getId();
+        this.roomId = room.getId();
+        this.roomNumber = room.getRoomNumber();
+        this.roomName = room.getName();
+    }
+}

--- a/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
@@ -1,0 +1,54 @@
+package com.example.baekseokmapbackend.favorite.service;
+
+import com.example.baekseokmapbackend.favorite.domain.Favorite;
+import com.example.baekseokmapbackend.favorite.dto.FavoriteAddRequest;
+import com.example.baekseokmapbackend.favorite.repository.FavoriteRepository;
+import com.example.baekseokmapbackend.map.domain.Room;
+import com.example.baekseokmapbackend.map.repository.RoomRepository;
+import com.example.baekseokmapbackend.user.domain.User;
+import com.example.baekseokmapbackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+
+    /**
+     * 즐겨찾기 추가 로직
+     */
+    @Transactional
+    public Long addFavorite(FavoriteAddRequest request) {
+        // 1. 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String studentId = authentication.getName(); // JWT 필터에서 저장한 학번
+
+        // 2. 사용자 엔티티 조회
+        User user = userRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 3. 강의실 엔티티 조회
+        Room room = roomRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new IllegalArgumentException("강의실을 찾을 수 없습니다."));
+
+        // 4. 이미 즐겨찾기에 추가되었는지 확인
+        favoriteRepository.findByUserAndRoom(user, room)
+                .ifPresent(favorite -> {
+                    throw new IllegalArgumentException("이미 즐겨찾기에 추가된 항목입니다.");
+                });
+
+        // 5. 즐겨찾기 엔티티 생성 및 저장
+        Favorite newFavorite = new Favorite(user, room);
+        Favorite savedFavorite = favoriteRepository.save(newFavorite);
+
+        return savedFavorite.getId();
+    }
+}

--- a/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
@@ -2,6 +2,7 @@ package com.example.baekseokmapbackend.favorite.service;
 
 import com.example.baekseokmapbackend.favorite.domain.Favorite;
 import com.example.baekseokmapbackend.favorite.dto.FavoriteAddRequest;
+import com.example.baekseokmapbackend.favorite.dto.FavoriteResponse;
 import com.example.baekseokmapbackend.favorite.repository.FavoriteRepository;
 import com.example.baekseokmapbackend.map.domain.Room;
 import com.example.baekseokmapbackend.map.repository.RoomRepository;
@@ -12,6 +13,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List; // 1. List 임포트 추가
+import java.util.stream.Collectors; // 2. Collectors 임포트 추가
 
 @Service
 @RequiredArgsConstructor
@@ -50,5 +54,26 @@ public class FavoriteService {
         Favorite savedFavorite = favoriteRepository.save(newFavorite);
 
         return savedFavorite.getId();
+    }
+
+    /**
+     * 즐겨찾기 목록 조회 로직
+     */
+    public List<FavoriteResponse> getFavorites() {
+        // 1. 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String studentId = authentication.getName();
+
+        // 2. 사용자 엔티티 조회
+        User user = userRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 3. 해당 사용자의 모든 즐겨찾기 목록을 DB에서 조회
+        List<Favorite> favorites = favoriteRepository.findAllByUser(user);
+
+        // 4. List<Favorite>를 List<FavoriteResponse>로 변환 (DTO 사용)
+        return favorites.stream()
+                .map(FavoriteResponse::new) // .map(favorite -> new FavoriteResponse(favorite))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/baekseokmapbackend/favorite/service/FavoriteService.java
@@ -14,8 +14,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List; // 1. List 임포트 추가
-import java.util.stream.Collectors; // 2. Collectors 임포트 추가
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,28 +31,19 @@ public class FavoriteService {
      */
     @Transactional
     public Long addFavorite(FavoriteAddRequest request) {
-        // 1. 현재 인증된 사용자 정보 가져오기
+        // ... (이전과 동일) ...
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String studentId = authentication.getName(); // JWT 필터에서 저장한 학번
-
-        // 2. 사용자 엔티티 조회
+        String studentId = authentication.getName();
         User user = userRepository.findByStudentId(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        // 3. 강의실 엔티티 조회
         Room room = roomRepository.findById(request.getRoomId())
                 .orElseThrow(() -> new IllegalArgumentException("강의실을 찾을 수 없습니다."));
-
-        // 4. 이미 즐겨찾기에 추가되었는지 확인
         favoriteRepository.findByUserAndRoom(user, room)
                 .ifPresent(favorite -> {
                     throw new IllegalArgumentException("이미 즐겨찾기에 추가된 항목입니다.");
                 });
-
-        // 5. 즐겨찾기 엔티티 생성 및 저장
         Favorite newFavorite = new Favorite(user, room);
         Favorite savedFavorite = favoriteRepository.save(newFavorite);
-
         return savedFavorite.getId();
     }
 
@@ -60,20 +51,37 @@ public class FavoriteService {
      * 즐겨찾기 목록 조회 로직
      */
     public List<FavoriteResponse> getFavorites() {
+        // ... (이전과 동일) ...
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String studentId = authentication.getName();
+        User user = userRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        List<Favorite> favorites = favoriteRepository.findAllByUser(user);
+        return favorites.stream()
+                .map(FavoriteResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 즐겨찾기 삭제 로직 (Room ID 기반)
+     */
+    @Transactional
+    public void deleteFavoriteByRoomId(Integer roomId) {
         // 1. 현재 인증된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String studentId = authentication.getName();
-
-        // 2. 사용자 엔티티 조회
         User user = userRepository.findByStudentId(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 3. 해당 사용자의 모든 즐겨찾기 목록을 DB에서 조회
-        List<Favorite> favorites = favoriteRepository.findAllByUser(user);
+        // 2. 삭제할 강의실 정보 가져오기
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("강의실을 찾을 수 없습니다."));
 
-        // 4. List<Favorite>를 List<FavoriteResponse>로 변환 (DTO 사용)
-        return favorites.stream()
-                .map(FavoriteResponse::new) // .map(favorite -> new FavoriteResponse(favorite))
-                .collect(Collectors.toList());
+        // 3. '사용자'와 '강의실'을 기준으로 즐겨찾기 항목을 DB에서 조회
+        Favorite favorite = favoriteRepository.findByUserAndRoom(user, room)
+                .orElseThrow(() -> new IllegalArgumentException("즐겨찾기 목록에 없는 항목입니다."));
+
+        // 4. 즐겨찾기 항목 삭제
+        favoriteRepository.delete(favorite);
     }
 }

--- a/test-api.http
+++ b/test-api.http
@@ -21,6 +21,7 @@ Content-Type: application/json
 > {%
     client.global.set("myRefreshToken", response.body.refreshToken);
     client.global.set("myAccessToken", response.body.accessToken);
+    client.log("myAccessToken: " + client.global.get("myAccessToken"));
 %}
 
 ###
@@ -41,4 +42,21 @@ Content-Type: application/json
 
 {
   "refreshToken": "{{myRefreshToken}}"
+}
+
+###
+
+# 6. [JWT 필터 테스트] GET + 토큰 (CSRF 검사 없음)
+GET http://localhost:8080/api/test
+Authorization: Bearer {{myAccessToken}}
+
+###
+
+# 7. [CSRF 테스트] POST + 토큰 (CSRF 검사 있음)
+POST http://localhost:8080/api/favorites
+Content-Type: application/json
+Authorization: Bearer {{myAccessToken}}
+
+{
+  "roomId": 1
 }

--- a/test-api.http
+++ b/test-api.http
@@ -60,3 +60,11 @@ Authorization: Bearer {{myAccessToken}}
 {
   "roomId": 1
 }
+
+###
+
+# 8. [성공 테스트] 즐겨찾기 목록 조회 API (인증 필요)
+#
+# 2번 로그인에서 발급받은 Access Token을 헤더에 추가해야 합니다.
+GET http://localhost:8080/api/favorites
+Authorization: Bearer {{myAccessToken}}

--- a/test-api.http
+++ b/test-api.http
@@ -46,13 +46,7 @@ Content-Type: application/json
 
 ###
 
-# 6. [JWT 필터 테스트] GET + 토큰 (CSRF 검사 없음)
-GET http://localhost:8080/api/test
-Authorization: Bearer {{myAccessToken}}
-
-###
-
-# 7. [CSRF 테스트] POST + 토큰 (CSRF 검사 있음)
+# 7. [성공 테스트] 즐겨찾기 추가 API (인증 필요)
 POST http://localhost:8080/api/favorites
 Content-Type: application/json
 Authorization: Bearer {{myAccessToken}}
@@ -64,7 +58,12 @@ Authorization: Bearer {{myAccessToken}}
 ###
 
 # 8. [성공 테스트] 즐겨찾기 목록 조회 API (인증 필요)
-#
-# 2번 로그인에서 발급받은 Access Token을 헤더에 추가해야 합니다.
 GET http://localhost:8080/api/favorites
+Authorization: Bearer {{myAccessToken}}
+
+###
+
+# 9. [성공 테스트] 즐겨찾기 삭제 API (인증 필요)
+# ?roomId=1 (우리가 7번에서 추가한 강의실)을 파라미터로 넘깁니다.
+DELETE http://localhost:8080/api/favorites?roomId=1
 Authorization: Bearer {{myAccessToken}}


### PR DESCRIPTION
- resolves #4 

### 🔍 설명
- `user` 인증 기능에 이어서, 사용자의 '즐겨찾기' 기능을 개발했습니다.
- API 명세서의 초기 `favoriteId` 기반 삭제 로직에서, **사용자 경험(UX)을 고려하여 `roomId`를 받아 삭제하는 로직**으로 변경하여 최종 구현했습니다.

### 🔥 할 일
- [x] **즐겨찾기 추가** (`POST /api/favorites`): `roomId`를 받아 즐겨찾기에 추가합니다.
- [x] **즐겨찾기 목록 조회** (`GET /api/favorites`): 현재 로그인한 사용자의 모든 즐겨찾기 목록을 반환합니다.
- [x] **즐겨찾기 삭제** (`DELETE /api/favorites`): `roomId`를 쿼리 파라미터로 받아 해당 항목을 삭제합니다.
- [x] **보안 적용**: `SecurityContextHolder`를 이용해 현재 로그인한 사용자를 식별하고, 본인의 즐겨찾기만 삭제할 수 있도록 로직을 구현했습니다.

### 🐴 할 말
- 테스트용 `rooms` 데이터를 DB에 직접 삽입하여 `201`, `200`, `204` 응답이 정상적으로 반환되는 것을 `.http` 파일로 모두 확인했습니다. 리뷰 부탁드립니다!